### PR TITLE
feat(infra): add dumb dockerfiles for each service (#1)

### DIFF
--- a/apps/admin-ui/.dockerignore
+++ b/apps/admin-ui/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/apps/admin-ui/Dockerfile
+++ b/apps/admin-ui/Dockerfile
@@ -1,0 +1,63 @@
+# ---------- Stage 1: Builder ----------
+FROM node:22-alpine AS builder
+
+# Enable pnpm
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+WORKDIR /app
+
+# Copy root workspace files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Copy app + shared packages metadata
+COPY apps/admin-ui/package.json ./apps/admin-ui/
+COPY packages/ui ./packages/ui
+COPY packages/typescript-config ./packages/typescript-config
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy full source
+COPY . .
+
+# Build Next.js app
+RUN pnpm --filter admin-ui build
+
+
+# ---------- Stage 2: Runner ----------
+FROM node:22-alpine AS runner
+
+# Create non-root user
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+# Enable pnpm
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+# Copy workspace metadata
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+
+# Copy admin-ui package metadata
+COPY --from=builder /app/apps/admin-ui/package.json ./apps/admin-ui/package.json
+
+# Install production deps only
+RUN pnpm install --prod --frozen-lockfile --filter admin-ui
+
+# Copy built output
+COPY --from=builder /app/apps/admin-ui/.next ./apps/admin-ui/.next
+
+# (optional but recommended)
+COPY --from=builder /app/apps/admin-ui/next.config.js ./apps/admin-ui/next.config.js
+
+# Permissions
+RUN chown -R appuser:appgroup /app
+USER appuser
+
+WORKDIR /app/apps/admin-ui
+
+EXPOSE 3001
+
+CMD ["pnpm", "start"]

--- a/apps/api/.dockerignore
+++ b/apps/api/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,55 @@
+# ---------- Stage 1: Builder ----------
+FROM node:22-alpine AS builder
+
+# Enable pnpm
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+WORKDIR /app
+
+# Copy only necessary files for dependency resolution
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/typescript-config ./packages/typescript-config
+
+# Install dependencies (workspace-aware)
+RUN pnpm install --frozen-lockfile
+
+# Copy full source
+COPY . .
+
+# Build only API
+RUN pnpm --filter api build
+
+
+# ---------- Stage 2: Runtime ----------
+FROM node:22-alpine AS runner
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+# Copy root workspace files
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+
+# Copy api package metadata
+COPY --from=builder /app/apps/api/package.json ./apps/api/package.json
+
+# Install only production dependencies for api
+RUN pnpm install --prod --frozen-lockfile --filter api
+
+# Copy compiled API output
+COPY --from=builder /app/apps/api/dist ./apps/api/dist
+
+RUN chown -R appuser:appgroup /app
+
+USER appuser
+
+WORKDIR /app/apps/api
+
+EXPOSE 4000
+
+CMD ["node", "dist/server.js"]

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,63 @@
+# ---------- Stage 1: Builder ----------
+FROM node:22-alpine AS builder
+
+# Enable pnpm
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+WORKDIR /app
+
+# Copy root workspace files
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Copy app + shared packages metadata
+COPY apps/web/package.json ./apps/web/
+COPY packages/ui ./packages/ui
+COPY packages/typescript-config ./packages/typescript-config
+
+# Install dependencies
+RUN pnpm install --frozen-lockfile
+
+# Copy full source
+COPY . .
+
+# Build Next.js app
+RUN pnpm --filter web build
+
+
+# ---------- Stage 2: Runner ----------
+FROM node:22-alpine AS runner
+
+# Create non-root user
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+WORKDIR /app
+
+# Enable pnpm
+RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+
+# Copy workspace metadata
+COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/pnpm-workspace.yaml ./pnpm-workspace.yaml
+
+# Copy web package metadata
+COPY --from=builder /app/apps/web/package.json ./apps/web/package.json
+
+# Install production deps only
+RUN pnpm install --prod --frozen-lockfile --filter web
+
+# Copy built output
+COPY --from=builder /app/apps/web/.next ./apps/web/.next
+
+# (optional but recommended)
+COPY --from=builder /app/apps/web/next.config.js ./apps/web/next.config.js
+
+# Permissions
+RUN chown -R appuser:appgroup /app
+USER appuser
+
+WORKDIR /app/apps/web
+
+EXPOSE 3000
+
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## What
Add Docker support for API, web, and admin-ui applications in the monorepo.

Closes #1 

## Why
The project previously relied only on pnpm run dev for local development, with no standardized way to run the system in a production-like environment.

This created issues with:

inconsistent setups across environments
slower onboarding for new developers
difficulty demonstrating the project reliably (e.g. interviews, reviews)

Introducing Docker improves reproducibility, portability, and overall project professionalism.

## How
Added multi-stage Dockerfiles for:

- apps/api (Node.js / Express backend)
- apps/web (Next.js frontend)
- apps/admin-ui (Next.js admin panel)

Each Dockerfile:

- uses node:22-alpine
- enables pnpm via Corepack
- builds using Turborepo (pnpm --filter <app> build)
- installs only production dependencies in runtime stage
- runs as a non-root user for security

Ensured proper handling of:

- pnpm workspace structure
- shared packages (@repo/ui, typescript-config)
- Next.js build outputs (.next)
- API compiled output (dist)

Standardized container startup commands:

- API → node dist/server.js
- Next.js apps → pnpm start

## Testing
Built images locally using:

`docker build -f apps/<app>/Dockerfile -t <image-name> .`

Verified runtime for each service:

`docker run -p <host>:<container> <image-name>`

Confirmed:

- API responds on /health
- web and admin-ui render correctly in browser
- no build/runtime errors in containers

## Screenshots
N/A (infrastructure-only change)
